### PR TITLE
Using argparse.ArgumentParser for CLI argument parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+__pycache__
+*.py[cod]
+
+

--- a/ht
+++ b/ht
@@ -204,8 +204,26 @@ def parse_arguments(argv):
     return n_head_lines, n_tail_lines, show_headers, filenames
 
 
-def main(argv, stdin):
+def parse_command_line_args(argv):
+    """
+    Normalizes shorthand arguments and sends result to the parser
+    returned by cli_arg_parser(). This returns the resulting namespace
+    object.
+    """
+    # match the first shorthand lines argument (eg. -3) and expand to -n flag (-n3)
+    arg_re = re.compile(r'\-[0-9]+')
+    matching_args = (i for i, x in enumerate(argv) if arg_re.match(x))
+    # find first index matching the regex, or None
+    idx = next(matching_args, None)
+    if idx is not None:
+        # we have a match: substitute -X with -nX
+        argv[idx] = '-n' + argv[idx][1:]
     args = cli_arg_parser().parse_args(argv[1:])
+    return args
+
+
+def main(argv, stdin):
+    args = parse_command_line_args(argv)
     n_head_lines = args.head_lines if args.head_lines is not None else args.lines
     n_tail_lines = args.tail_lines if args.tail_lines is not None else args.lines
 

--- a/ht
+++ b/ht
@@ -92,7 +92,8 @@ def cli_arg_parser():
                         action='store_true',
                         help='Print headers')
     parser.add_argument('-q', '--quiet',
-                        action='store_true',
+                        action='store_false',
+                        dest='verbose',
                         help='Do not print headers.')
     parser.add_argument('-n', '--lines',
                         type=int,
@@ -112,11 +113,10 @@ def cli_arg_parser():
                         type=str,
                         nargs='*',
                         default=['-'],
-                        help='''    Print the beginning and ending of each file.
-                            Prints '...' for omitted lines.
-                            Defaults to first 10 and last 10 lines.
-                            Standard input may be specified by - argument.
-                            If no files are specified, uses standard input.''')
+                        help='''Print the beginning and ending of each file. Prints '...' for
+                                omitted lines. Defaults to first 10 and last 10 lines.
+                                Standard input may be specified by - argument.
+                                If no files are specified, uses standard input.''')
 
     return parser
 
@@ -205,15 +205,17 @@ def parse_arguments(argv):
 
 
 def main(argv, stdin):
-    n_head_lines, n_tail_lines, show_headers, filenames = parse_arguments(argv)
+    args = cli_arg_parser().parse_args(argv[1:])
+    n_head_lines = args.head_lines if args.head_lines is not None else args.lines
+    n_tail_lines = args.tail_lines if args.tail_lines is not None else args.lines
 
-    for i, filename in enumerate(filenames):
+    for i, filename in enumerate(args.filenames):
         if filename == '-':
             f = stdin
             filename = 'standard input'
         else:
             f = open(filename)
-        show_header(show_headers, filename, i)
+        show_header(args.verbose, filename, i)
         do_file(f, n_head_lines, n_tail_lines)
 
 

--- a/ht
+++ b/ht
@@ -73,12 +73,52 @@ LICENSE
 '''
 
 from __future__ import print_function
-import sys
+
 import re
+import sys
 from itertools import islice
 from collections import deque
+from argparse import ArgumentParser
 
 DEFAULT_N_LINES = 10
+
+
+def cli_arg_parser():
+    '''Returns the command line ArgumentParser object'''
+    parser = ArgumentParser('ht',
+                            description='(headtail) output the beginning and ending of files',
+                            )
+    parser.add_argument('-v', '--verbose',
+                        action='store_true',
+                        help='Print headers')
+    parser.add_argument('-q', '--quiet',
+                        action='store_true',
+                        help='Do not print headers.')
+    parser.add_argument('-n', '--lines',
+                        type=int,
+                        default=10,
+                        help='Specify the number of lines from beginning and end of file to '
+                             'print. In the -n n option, the first n is literal, the second '
+                             'is the number.')
+    parser.add_argument('--head-lines',
+                        type=int,
+                        nargs='?',
+                        help='Specify the number of lines from beginning of file to print.')
+    parser.add_argument('--tail-lines',
+                        type=int,
+                        nargs='?',
+                        help='Specify the number of lines from end of file to print.')
+    parser.add_argument('filenames',
+                        type=str,
+                        nargs='*',
+                        default=['-'],
+                        help='''    Print the beginning and ending of each file.
+                            Prints '...' for omitted lines.
+                            Defaults to first 10 and last 10 lines.
+                            Standard input may be specified by - argument.
+                            If no files are specified, uses standard input.''')
+
+    return parser
 
 
 def do_file(f, n_head_lines, n_tail_lines):


### PR DESCRIPTION
Added function `cli_arg_parser` used to create the parser (this returns the parser object, rather than wrapping the parsing itself, offering more flexibility). Help options copied from module docstring. If you want to use \_\_doc\_\_ as "program usage", you can set that in ArgumentParser constructor ([relevant doc](https://docs.python.org/3/library/argparse.html#usage)).

The only inelegant thing I see is the setting of n_{head,tail}_lines variables on lines 209 & 210; it would be nicer if you could args.get("foo", "default") but args is more like namedtuple than dict.

The `parse_arguments` function has be left for posterity.
